### PR TITLE
fixed the typewriter text  alignment

### DIFF
--- a/src/app/components/Typewriter.tsx
+++ b/src/app/components/Typewriter.tsx
@@ -43,9 +43,10 @@ function Typewriter() {
 
   return (
     <div className="inline text-center">
-      <p id="typewriter" className="py-4 w-full text-bold text-5xl italic">
+      <p id="typewriter" className="py-4 w-full text-bold text-5xl italic" style={{ height: "1.2em" }}>
         {currentText}
       </p>
+      
     </div>
   );
 }


### PR DESCRIPTION
I visited your website and saw this weird alignment issue in the hero section, where the rest of the text comes down whenever the typewriter text disappears. Which was kinda annoying so I fixed it.